### PR TITLE
Merge new autograd implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,4 +46,5 @@
 - [ ] Refactoring
     - [x] Rewrite with generics
     - [ ] Implement `Debug` to print tensors
+    - [ ] Improve performance with 100% reference-based implementation and reduced number of clones
 - [ ] Benchmarks

--- a/examples/autograd.rs
+++ b/examples/autograd.rs
@@ -1,4 +1,6 @@
 
+use std::borrow::Borrow;
+
 use elara_log::prelude::*;
 use elara_math::prelude::*;
 
@@ -6,8 +8,8 @@ fn main() {
     // Initialize logging library
     Logger::new().init().unwrap();
 
-    let mut x: Tensor<1> = tensor![3.0];
-    let mut y = &x * &x;
+    let x: Tensor<1> = tensor![3.0];
+    let y = &x * &x;
 
     y.backward();
     println!("dy/dx: {:?}", x.grad().data);

--- a/examples/autograd.rs
+++ b/examples/autograd.rs
@@ -1,6 +1,3 @@
-
-use std::borrow::Borrow;
-
 use elara_log::prelude::*;
 use elara_math::prelude::*;
 

--- a/examples/tiny_nn.rs
+++ b/examples/tiny_nn.rs
@@ -25,15 +25,15 @@ fn main() {
     println!("Weights before training: {:?}", weights);
     for epoch in 0..EPOCHS {
         let output = train_data.matmul(&weights).sigmoid();
-        let mut loss = elara_math::mse(&output, &train_labels);
+        let loss = elara_math::mse(&output, &train_labels);
         println!("Epoch {} loss: {:?}", epoch, loss);
         loss.backward();
         let adjustment = weights.grad() * LR;
-        weights -= Tensor::new_from_f64(adjustment);
+        weights = weights - Tensor::new(adjustment);
         weights.zero_grad();
     }
     let pred_data: Tensor<2> = tensor![[1.0, 0.0, 0.0]];
     let pred = &pred_data.matmul(&weights).sigmoid();
     println!("Weights after training: {:?}", weights);
-    println!("Prediction [1, 0, 0] -> {:?}", pred.to_ndarray().data);
+    println!("Prediction [1, 0, 0] -> {:?}", pred.borrow().data);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use tensor::*;
 
 pub mod prelude;
 
-pub fn mse<const N: usize>(predicted: &Tensor<N>, target: &Tensor<N>) -> Tensor<N>
-{
-    Tensor::new(array!(((target - predicted).pow(2.0)).mean()))
-}
+// pub fn mse<const N: usize>(predicted: &Tensor<N>, target: &Tensor<N>) -> Tensor<N>
+// {
+//     Tensor::new(array!(((target - predicted).pow(2.0)).mean()))
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use tensor::*;
 
 pub mod prelude;
 
-// pub fn mse<const N: usize>(predicted: &Tensor<N>, target: &Tensor<N>) -> Tensor<N>
-// {
-//     Tensor::new(array!(((target - predicted).pow(2.0)).mean()))
-// }
+pub fn mse<const N: usize>(predicted: &Tensor<N>, target: &Tensor<N>) -> Tensor<N>
+{
+    (target - predicted).pow(2.0).mean()
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,1 @@
-pub use crate::{tensor, val, array, Value, Tensor, NdArray};
+pub use crate::{tensor, array, Tensor, NdArray};

--- a/src/tensor/array/mod.rs
+++ b/src/tensor/array/mod.rs
@@ -1,11 +1,10 @@
 use elara_log::prelude::*;
 use std::iter::{Product, Sum};
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Deref};
 use std::{
     fmt::Debug,
     ops::{Add, Div, Index, IndexMut, Mul, Neg, Sub},
 };
-use crate::{Value, val};
 use crate::num::randf;
 
 pub mod utils;
@@ -120,6 +119,10 @@ impl<T: Clone, const N: usize> NdArray<T, N> {
             data: data.into_iter().map(f).collect(),
             shape: self.shape
         }
+    }
+
+    pub fn fill(&mut self, val: T) {
+        self.data = vec![val; self.shape.iter().product()]
     }
 
     // Referenced https://codereview.stackexchange.com/questions/256345/n-dimensional-array-in-rust
@@ -253,22 +256,6 @@ impl NdArray<f64, 2> {
     		for col in 0..b.shape[1] {
     			for el in 0..b.shape[0] {
     				res[&[row, col]] += self[&[row, el]] * b[&[el, col]]
-    			}
-    		}
-    	}
-        res
-    }
-}
-
-impl NdArray<Value, 2> {
-    /// Finds the matrix product of 2 matrices of `Value`s - used for ML
-    pub fn matmul(&self, b: &NdArray<Value, 2>) -> NdArray<Value, 2> {
-        assert_eq!(self.shape[1], b.shape[0]);
-        let mut res: NdArray<Value, 2> = NdArray::zeros([self.shape[0], b.shape[1]]).mapv(|el: f64| val!(el));
-    	for row in 0..self.shape[0] {
-    		for col in 0..b.shape[1] {
-    			for el in 0..b.shape[0] {
-    				res[&[row, col]] += self[&[row, el]].clone() * b[&[el, col]].clone()
     			}
     		}
     	}

--- a/src/tensor/array/mod.rs
+++ b/src/tensor/array/mod.rs
@@ -109,6 +109,10 @@ impl<T: Clone, const N: usize> NdArray<T, N> {
         self.data.iter()
     }
     
+    pub fn first(&self) -> Option<&T> {
+        self.data.first()
+    }
+    
     pub fn mapv<B, F>(&self, f: F) -> NdArray<B, N>
     where T: Clone,
           F: FnMut(T) -> B,

--- a/src/tensor/array/mod.rs
+++ b/src/tensor/array/mod.rs
@@ -1,6 +1,6 @@
 use elara_log::prelude::*;
 use std::iter::{Product, Sum};
-use std::ops::{AddAssign, Deref};
+use std::ops::{AddAssign, SubAssign, Deref};
 use std::{
     fmt::Debug,
     ops::{Add, Div, Index, IndexMut, Mul, Neg, Sub},
@@ -398,6 +398,31 @@ impl<T: Clone + Sub<Output = T>, const N: usize> Sub<&NdArray<T, N>> for &NdArra
             .collect();
 
         NdArray::from(difference_vec, self.shape)
+    }
+}
+
+// Elementwise subassign
+impl<T: Clone + Sub<Output = T>, const N: usize> SubAssign<&NdArray<T, N>> for &mut NdArray<T, N> {
+    fn sub_assign(&mut self, rhs: &NdArray<T, N>) {
+        let sub_vec = self
+            .data
+            .iter()
+            .zip(&rhs.data)
+            .map(|(a, b)| a.clone() - b.clone())
+            .collect();
+        self.data = sub_vec;
+    }
+}
+
+impl<T: Clone + Sub<Output = T>, const N: usize> SubAssign<NdArray<T, N>> for NdArray<T, N> {
+    fn sub_assign(&mut self, rhs: NdArray<T, N>) {
+        let sub_vec: Vec<T> = self
+            .data
+            .iter()
+            .zip(&rhs.data)
+            .map(|(a, b)| a.clone() - b.clone())
+            .collect();
+        self.data = sub_vec;
     }
 }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1,160 +1,174 @@
 mod array;
 pub use array::{NdArray, utils::*};
 
-mod autograd;
-pub use autograd::Value;
-
-use crate::num::randf;
-use crate::val;
+use crate::array;
 
 use std::{
+    cell::{RefCell, Ref, RefMut},
+    collections::HashSet,
+    hash::{Hash, Hasher},
     fmt::Debug,
-    ops::{Add, Mul, Sub, Index, AddAssign, SubAssign},
+    ops::{Add, Mul, Sub, Index, AddAssign, SubAssign, Deref, DerefMut}, rc::Rc,
 };
+
+use uuid::Uuid;
 
 #[macro_export]
 macro_rules! tensor {
     [$([$($x:expr),* $(,)*]),+ $(,)*] => {
-        Tensor::new($crate::array!($([$($x,)*],)*).mapv(|elem: f64| $crate::val!(elem)))
+        Tensor::new($crate::array!($([$($x,)*],)*))
     };
     [$($x:expr),*] => {
-        Tensor::new($crate::array!($($x),*).mapv(|elem: f64| $crate::val!(elem)))
+        Tensor::new($crate::array!($($x),*))
     };
 }
 
-pub struct Tensor<const N: usize>(NdArray<Value, N>);
-
-impl<const N: usize> Tensor<N> {
-    pub fn new(array: NdArray<Value, N>) -> Tensor<N> {
-        Tensor(array)
+#[macro_export]
+macro_rules! scalar {
+    ($x:expr) => {
+        Tensor::from_f64($crate::array!($x))
     }
+}
 
-    pub fn new_from_f64(array: NdArray<f64, N>) -> Tensor<N> {
-        Tensor(array.mapv(|val| val!(val)))
-    }
+pub struct TensorData<const N: usize> {
+    pub data: NdArray<f64, N>,
+    pub grad: NdArray<f64, N>,
+    pub uuid: Uuid,
+    backward: Option<fn(&TensorData<N>)>,
+    prev: Vec<Tensor<N>>,
+    op: Option<String>
+}
 
-    pub fn arange<I: Iterator<Item = i32>>(range: I) -> Tensor<N> {
-        Tensor(NdArray::arange(range).mapv(|el| val!(el)))
-    }
+#[derive(Clone)]
+pub struct Tensor<const N: usize>(Rc<RefCell<TensorData<N>>>);
 
-    pub fn zeros(shape: [usize; N]) -> Tensor<N> {
-        let array = NdArray {
-            shape,
-            data: vec![val!(0.0); shape.iter().product()],
-        };
-        Tensor(array)
+impl<const N: usize> Hash for Tensor<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.borrow().uuid.hash(state);
     }
+}
 
-    pub fn rand(shape: [usize; N]) -> Tensor<N> {
-        let empty_vec = vec![0.0; shape.iter().product()];
-        let data = empty_vec.iter().map(|_| crate::val!(randf())).collect();
-        let array = NdArray {
-            shape,
-            data
-        };
-        Tensor(array)
+impl<const N: usize> PartialEq for Tensor<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.borrow().uuid == other.borrow().uuid
     }
+}
 
-    pub fn backward(&mut self) {
-        self.0.mapv(|val: Value| val.backward());
+impl<const N: usize> Eq for Tensor<N> {}
+
+impl<const N: usize> Deref for Tensor<N> {
+    type Target = Rc<RefCell<TensorData<N>>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
-    
-    pub fn grad(&mut self) -> NdArray<f64, N> {
-        let data = self.0.data.clone();
-        let gradients = data.into_iter().map(move |val| val.borrow().grad).collect();
-        NdArray {
-            data: gradients,
-            shape: self.0.shape
+}
+
+impl<const N: usize> DerefMut for Tensor<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<const N: usize> TensorData<N> {
+    fn new(data: NdArray<f64, N>) -> TensorData<N> {
+        let shape = data.shape.clone();
+        TensorData {
+            data, 
+            grad: NdArray::zeros(shape),
+            uuid: Uuid::new_v4(),
+            backward: None,
+            prev: Vec::new(),
+            op: None
         }
     }
+}
 
-    pub fn set_data(&mut self, array: NdArray<Value, N>) {
-        self.0 = array;
-    }
-
-    pub fn to_ndarray(&self) -> NdArray<f64, N> {
-        self.0.mapv(|val| val.borrow().data)
-    }
-
-    pub fn zero_grad(&mut self) {
-        self.0.mapv(|val| val.borrow_mut().zero_grad());
+impl<const N: usize> Tensor<N> {
+    pub fn new(array: NdArray<f64, N>) -> Tensor<N> {
+        Tensor(Rc::new(RefCell::new(TensorData::new(array))))
     }
 
     pub fn shape(&self) -> [usize; N] {
-        self.0.shape
+        self.borrow().data.shape
     }
-    
+
+    pub fn rand(shape: [usize; N]) -> Tensor<N> {
+        let arr = NdArray::random(shape);
+        Tensor::new(arr)
+    }
+
+    pub fn from_f64(val: f64) -> Tensor<N> {
+        Tensor::new(array!(val))
+    }
+
+    pub fn grad(&self) -> NdArray<f64, N> {
+        self.borrow().grad.clone()
+    }
+
     pub fn reshape(&mut self, shape: [usize; N]) -> Tensor<N> {
-        let arr = NdArray {
-            shape,
-            data: self.0.data.clone()
-        };
-        Tensor(arr)
+        Tensor::new(self.borrow().data.clone().reshape(shape))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Value> {
-        self.0.data.iter()
-    }
-
-    pub fn len(&self) -> Value {
-        val!(self.0.data.len() as f64)
-    }
-
-    pub fn sum(&self) -> Value {
-        self.0.data.iter().cloned().sum()
-    }
+    // pub fn data(&self) -> impl Deref<Target = NdArray<f64, N>> + '_ {
+    //     Ref::map((*self.0).borrow(), |mi| &mi.data)
+    // }
     
-    pub fn mean(&self) -> Value {
-        self.sum() / self.len()
+    // pub fn data_mut(&self) -> impl Deref<Target = NdArray<f64, N>> + '_ {
+    //     RefMut::map((*self.0).borrow_mut(), |mi| &mut mi.data)
+    // }
+
+    // pub fn grad(&self) -> impl Deref<Target = NdArray<f64, N>> + '_ {
+    //     Ref::map((*self.0).borrow(), |mi| &mi.grad)
+    // }
+
+    pub fn grad_mut(&self) -> impl DerefMut<Target = NdArray<f64, N>> + '_ {
+        RefMut::map((*self.0).borrow_mut(), |mi| &mut mi.grad)
     }
 
-    pub fn exp(&self) -> Tensor<N> {
-        Tensor(self.0.mapv(|val| val.exp()))
+    pub fn backward(&self) {
+        let mut topo: Vec<Tensor<N>> = vec![];
+        let mut visited: HashSet<Tensor<N>> = HashSet::new();
+        self._build_topo(&mut topo, &mut visited);
+        topo.reverse();
+
+        self.grad_mut().fill(1.0);
+        for v in topo {
+            if let Some(backprop) = v.borrow().backward {
+                backprop(&v.borrow());
+            }
+        }
     }
 
-    pub fn sigmoid(&self) -> Tensor<N> {
-        Tensor(self.0.mapv(|val| 1.0 / (1.0 + (-val).exp())))
-    }
-
-    pub fn relu(&self) -> Tensor<N> {
-        Tensor(self.0.mapv(|val| val.relu()))
-    }
-
-    pub fn pow(&self, base: f64) -> Tensor<N> {
-        Tensor(self.0.mapv(|val| val.pow(base)))
+    fn _build_topo(&self, topo: &mut Vec<Tensor<N>>, visited: &mut HashSet<Tensor<N>>) {
+        if visited.insert(self.clone()) {
+            self.borrow().prev.iter().for_each(|child| {
+                child._build_topo(topo, visited);
+            });
+            topo.push(self.clone());
+        }
     }
 }
 
-impl Tensor<2> {
-    pub fn matmul(&self, b: &Tensor<2>) -> Tensor<2> {
-    	assert_eq!(self.0.shape[1], b.0.shape[0]);
-        let a_array = &self.0;
-        let b_array = &b.0;
-        let res = a_array.matmul(b_array);
-        let res: NdArray<Value, 2> = res.mapv(|val| val!(val));
-        Tensor(res)
-    }
-}
-
+// TODO: better printing of tensors
 impl<const N: usize> Debug for Tensor<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Tensor({:?}, shape={:?})", self.to_ndarray().data, self.shape())
+        write!(f, "Tensor({:?}, shape={:?})", self.borrow().data.clone(), self.shape())
     }
 }
 
-impl<const N: usize> Index<&[usize; N]> for Tensor<N> {
-    type Output = Value;
-
-    fn index(&self, index: &[usize; N]) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 // Elementwise addition by reference
 impl<const N: usize> Add<&Tensor<N>> for &Tensor<N> {
     type Output = Tensor<N>;
     fn add(self, rhs: &Tensor<N>) -> Self::Output {
-        Tensor::new(&self.0 + &rhs.0)
+        let out = Tensor::new(self.borrow().data.clone() + rhs.borrow().data.clone());
+        out.borrow_mut().prev = vec![self.clone(), rhs.clone()];
+        out.borrow_mut().op = Some(String::from("+"));
+        out.borrow_mut().backward = Some(|value: &TensorData<N>| {
+            value.prev[0].borrow_mut().grad += value.grad.clone();
+            value.prev[1].borrow_mut().grad += value.grad.clone();
+        });
+        out
     }
 }
 
@@ -166,49 +180,28 @@ impl<const N: usize> Add<Tensor<N>> for Tensor<N> {
     }
 }
 
-// Elementwise addassign without reference
-impl<const N: usize> AddAssign<Tensor<N>> for Tensor<N> {
-    fn add_assign(&mut self, rhs: Tensor<N>) {
-        let addassign_arr = &self.0 + &rhs.0;
-        self.set_data(addassign_arr)
-    }
-}
-
-// Elementwise subtraction by reference
-impl<const N: usize> Sub<&Tensor<N>> for &Tensor<N> {
-    type Output = Tensor<N>;
-    fn sub(self, rhs: &Tensor<N>) -> Self::Output {
-        Tensor::new(&self.0 - &rhs.0)
-    }
-}
-
-// Elementwise subtraction without reference
-impl<const N: usize> Sub<&Tensor<N>> for Tensor<N> {
-    type Output = Tensor<N>;
-    fn sub(self, rhs: &Tensor<N>) -> Self::Output {
-        &self - rhs
-    } 
-}
-
-// Elementwise subtract assign without reference
-impl<const N: usize> SubAssign<Tensor<N>> for Tensor<N> {
-    fn sub_assign(&mut self, rhs: Tensor<N>) {
-        let subassign_arr = &self.0 - &rhs.0;
-        self.set_data(subassign_arr)
-    }
-}
-
-// Elementwise multiplication by reference
+// Elementwise multiplication without reference
 impl<const N: usize> Mul<&Tensor<N>> for &Tensor<N> {
     type Output = Tensor<N>;
+
     fn mul(self, rhs: &Tensor<N>) -> Self::Output {
-        Tensor::new(&self.0 * &rhs.0)
+        let out = Tensor::new(self.borrow().data.clone() * rhs.borrow().data.clone());
+        out.borrow_mut().prev = vec![self.clone(), rhs.clone()];
+        out.borrow_mut().op = Some(String::from("×"));
+        out.borrow_mut().backward = Some(|value: &TensorData<N>| {
+            let a_data = value.prev[0].borrow().data.clone();
+            let b_data = value.prev[1].borrow().data.clone();
+            value.prev[0].borrow_mut().grad += b_data * value.grad.clone();
+            value.prev[1].borrow_mut().grad += a_data * value.grad.clone();
+        });
+        out
     }
 }
 
 // Elementwise multiplication without reference
 impl<const N: usize> Mul<Tensor<N>> for Tensor<N> {
     type Output = Tensor<N>;
+
     fn mul(self, rhs: Tensor<N>) -> Self::Output {
         &self * &rhs
     }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -153,6 +153,18 @@ impl<const N: usize> Tensor<N> {
         out
     }
     
+    pub fn sigmoid(&self) -> Tensor<N> {
+        let sigmoid_array = self.borrow().data.mapv(|val| 1.0 / (1.0 + (-val).exp()));
+        let out = Tensor::new(sigmoid_array);
+        out.borrow_mut().prev = vec![self.clone()];
+        out.borrow_mut().op = Some(String::from("exp"));
+        out.borrow_mut().backward = Some(|value: &TensorData<N>| {
+            let prev = value.prev[0].borrow().data.clone();
+            value.prev[0].borrow_mut().grad += prev.mapv(|val| val.exp() / (1.0 + val.exp()).powf(2.0));
+        });
+        out
+    }
+    
     pub fn index_mut(&mut self, idx: &[usize; N]) -> f64 {
         self.borrow_mut().data[idx]
     }


### PR DESCRIPTION
This PR implements a faster autograd implementation using `NdArray` backed tensors rather than containers of `Values`. A 5x performance improvement in debug mode, and up to 19x performance improvement in release mode, was realized.